### PR TITLE
Minesweeper redux: reducing explosives under doors (and in general.)

### DIFF
--- a/code/game/objects/random/traps/traps.dm
+++ b/code/game/objects/random/traps/traps.dm
@@ -5,9 +5,9 @@
 
 /obj/random/traps/item_to_spawn()
 	var/list/possible_traps = list(/obj/structure/wire_splicing = 1,
-	/obj/item/mine/armed = 0.15,
-	/obj/item/mine/improvised/armed = 0.30,
-	/obj/item/beartrap/armed = 0.45,
+	/obj/item/mine/armed = 0.05,
+	/obj/item/mine/improvised/armed = 0.10,
+	/obj/item/beartrap/armed = 0.65,
 	/obj/item/beartrap/makeshift/armed = 0.8)
 
 	//Check that its possible to spawn the chosen trap at this location


### PR DESCRIPTION
Significantly lowers the chance of landom randmine spawns from random trap locations (namely under EVERY DOOR IN MAINTANANCE)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
Landmines, are hilariously lethal when it comes to being a maintenance trap to the point where it is obnoxious.  They are the second leading cause of death after infections, and it makes no sense that they are so common on colony grounds of all places. Hardspawns are one thing, but given random traps can spawn under any door leading to  or inside maintenance tunnels (which is to say, a large number of them) and it becomes nothing short of obnoxious. Besides, it makes no sense that a colony with such heavy security would leave bombs laying about under random doors directly neighboring hallways.
<hr>
</details>

## Changelog
:cl:
balance: The marshals and blackshield have increased their ordnance disposal training between shifts. You should see fewer landmines in and around the colony. 
/:cl:

